### PR TITLE
Support fixedProbabilities

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,13 +4,14 @@ const getStdin = require('get-stdin');
 const generator = require('./generator');
 
 cli
-  .version('0.1.1')
+  .version('0.1.2')
   .usage('json-schema.yaml -y -l es_MX -r user')
   .option('-r, --rootSchema <value>', 'Set root schema from definitions')
   .option('-l, --locale [value]', 'Faker locale. Review Faker.js for more details.')
   .option('-i, --max-items <n>', 'Configure a maximum amount of items to generate in an array. This will override the maximum items found inside a JSON Schema', parseInt)
   .option('-m, --max-length <n>', 'Configure a maximum length to allow generating strings for. This will override the maximum length found inside a JSON Schema', parseInt)
   .option('-p, --optionals-probability <n>', 'When 0.0, only required properties will be generated; when 1.0, all properties are generated', parseFloat)
+  .option('-f, --fixed-probabilities', 'When set, specified optionals-probability value will always be equal, rather than less than or equal to given value')
   .option('-y, --yaml', 'YAML input')
   .parse(process.argv);
 
@@ -27,6 +28,9 @@ if (cli.maxLength) {
 }
 if (cli.optionalsProbability) {
   settings.optionalsProbability = cli.optionalsProbability;
+  if (cli.fixedProbabilities) {
+    settings.fixedProbabilities = cli.fixedProbabilities;
+  }
 }
 
 const locale = cli.locale ? cli.locale : 'en';


### PR DESCRIPTION
https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options

Without this, optionalProbability would be from 0% to given percent. This means that even with optionalProbability set to 1.0, there's a 50% chance the optional values wont actually be included